### PR TITLE
removing sample from cellranger command

### DIFF
--- a/utilities/alignment/10x_count.py
+++ b/utilities/alignment/10x_count.py
@@ -106,7 +106,6 @@ def main(logger):
     command = [CELLRANGER, 'count',
                '--localmem=240', '--nosecondary', '--disable-ui',
                '--expect-cells={}'.format(args.cell_count),
-               '--sample={}'.format(sample_id),
                '--id={}'.format(sample_id),
                '--fastqs={}'.format(fastq_path),
                '--transcriptome={}'.format(genome_dir)]


### PR DESCRIPTION
In cases when the files don't have the same name as the ID, this caused alignment to fail because it treats `sample` as a file prefix.