### PR TITLE
add gencode reference

### DIFF
--- a/src/utilities/alignment/run_star_and_htseq.py
+++ b/src/utilities/alignment/run_star_and_htseq.py
@@ -21,12 +21,14 @@ S3_REFERENCE = {"east": "czi-hca", "west": "czbiohub-reference"}
 reference_genomes = {
     "homo": "HG38-PLUS",
     "hg38-plus": "HG38-PLUS",
+    "homo.gencode.v30": "homo.gencode.v30.annotation.ERCC92"
     "mus": "MM10-PLUS",
     "mm10-plus": "MM10-PLUS",
     "microcebus": "MicMur3-PLUS",
     "gencode.vM19": "gencode.vM19",
     "gencode.vM19.ERCC": "gencode.vM19.ERCC.SP1",
-    "zebrafish-plus": "danio_rerio_plus_STAR2.6.1d"
+    "zebrafish-plus": "danio_rerio_plus_STAR2.6.1d",
+    "homo.gencode.v30-plus-HAV18": "gencode.v30.annotation.ERCC92.HAV_18f_KP879216"
 }
 
 deprecated = {"homo": "hg38-plus", "mus": "mm10-plus"}

--- a/src/utilities/alignment/run_star_and_htseq.py
+++ b/src/utilities/alignment/run_star_and_htseq.py
@@ -21,8 +21,7 @@ S3_REFERENCE = {"east": "czi-hca", "west": "czbiohub-reference"}
 reference_genomes = {
     "homo": "HG38-PLUS",
     "hg38-plus": "HG38-PLUS",
-    "homo.gencode.v30": "homo.gencode.v30.annotation.ERCC92",
-    #"mus": "MM10-PLUS",
+    "mus": "MM10-PLUS",
     "mm10-plus": "MM10-PLUS",
     "microcebus": "MicMur3-PLUS",
     "gencode.vM19": "gencode.vM19",

--- a/src/utilities/alignment/run_star_and_htseq.py
+++ b/src/utilities/alignment/run_star_and_htseq.py
@@ -22,7 +22,7 @@ reference_genomes = {
     "homo": "HG38-PLUS",
     "hg38-plus": "HG38-PLUS",
     "homo.gencode.v30": "homo.gencode.v30.annotation.ERCC92",
-    "mus": "MM10-PLUS",
+    #"mus": "MM10-PLUS",
     "mm10-plus": "MM10-PLUS",
     "microcebus": "MicMur3-PLUS",
     "gencode.vM19": "gencode.vM19",

--- a/src/utilities/alignment/run_star_and_htseq.py
+++ b/src/utilities/alignment/run_star_and_htseq.py
@@ -21,6 +21,7 @@ S3_REFERENCE = {"east": "czi-hca", "west": "czbiohub-reference"}
 reference_genomes = {
     "homo": "HG38-PLUS",
     "hg38-plus": "HG38-PLUS",
+    "homo.gencode.v30": "homo.gencode.v30.annotation.ERCC92",
     "mus": "MM10-PLUS",
     "mm10-plus": "MM10-PLUS",
     "microcebus": "MicMur3-PLUS",

--- a/src/utilities/alignment/run_star_and_htseq.py
+++ b/src/utilities/alignment/run_star_and_htseq.py
@@ -21,7 +21,7 @@ S3_REFERENCE = {"east": "czi-hca", "west": "czbiohub-reference"}
 reference_genomes = {
     "homo": "HG38-PLUS",
     "hg38-plus": "HG38-PLUS",
-    "homo.gencode.v30": "homo.gencode.v30.annotation.ERCC92"
+    "homo.gencode.v30": "homo.gencode.v30.annotation.ERCC92",
     "mus": "MM10-PLUS",
     "mm10-plus": "MM10-PLUS",
     "microcebus": "MicMur3-PLUS",

--- a/src/utilities/alignment/run_star_and_htseq.py
+++ b/src/utilities/alignment/run_star_and_htseq.py
@@ -21,7 +21,7 @@ S3_REFERENCE = {"east": "czi-hca", "west": "czbiohub-reference"}
 reference_genomes = {
     "homo": "HG38-PLUS",
     "hg38-plus": "HG38-PLUS",
-    "homo.gencode.v30": "homo.gencode.v30.annotation.ERCC92",
+    "homo.gencode.v30.ERCC.chrM": "homo.gencode.v30.annotation.ERCC92",
     "mus": "MM10-PLUS",
     "mm10-plus": "MM10-PLUS",
     "microcebus": "MicMur3-PLUS",


### PR DESCRIPTION
two new references added to the S3 bucket:
1. human genome gencode v30 + ERCC + ChrM
2. the one above + HAV_18F virus