### PR TITLE
updated README.md with reference genomes and alignment documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@ A collection of scripts for common data management and processing tasks
 | ----------- | -------- | ----------- |
 | Demux a standard sequencing run | `evros demux.bcl2fastq --exp_id YYMMDD_EXP_ID` | Assumes your sample sheet is uploaded to S3.|
 | Demux a 10X run | `evros demux.10x_mkfastq --exp_id YYMMDD_EXP_ID` | Again, assumes a sample sheet is present on S3 |
-| Align using STAR and htseq | ```aws_star [see --help for taxons] [# partitions] --s3_input_path s3://input-bucket/path/to/fastqs --s3_output_path s3://output-bucket/path/for/results > your_script.sh``` | Creates a shell script locally to launch many alignments using `source your_script.sh` |
 | Align a 10X run | ```evros alignment.10x_count --taxon [see --help for options] --s3_input_dir s3://input-bucket/path/to/fastqs --s3_output_dir s3://output-bucket/path/for/results``` | Run once for each channel of the run. Very slow! |
+| Align using STAR and htseq (slow) | ```evros alignment.run_star_and_htseq --taxon [see --help for options] --num_partitions NUM_PARTITIONS --partition_id PARTITION_ID --s3_input_path s3://input-bucket/path/to/fastqs --s3_output_path s3://output-bucket/path/for/results``` | Run once for each channel of the run. Very slow! |
+| Align using STAR and htseq (preferred) | ```aws_star [see --help for more information] taxon num_partitions s3://input-bucket/path/to/fastqs --s3_output_path s3://output-bucket/path/for/results > your_script.sh``` | Creates a shell script locally to launch many alignments using `source your_script.sh` |
 | Run Velocyto | ```aws_velocyto [see --help for taxon] [# partitions] --s3_input_path s3://input-bucket/path/to/star_output --s3_output_path s3://output-bucket/path/for/results > your_script.sh``` | Creates a shell script locally to run velocyto on STAR output |
 | Create a download token | `aws_access fastqs/YYMMDD_EXP_ID [optional bucket] > download_instructions.txt` | Defaults to the `czb-seqbot` bucket |
 
@@ -148,26 +149,94 @@ If you want to stick the results somewhere other than czb-seqbot/fastqs, you can
 
 ### How to align some stuff:
 
+#### How to choose the right genome (--taxon argument in running the alignment job):
+
+To choose the right genome as the --taxon input, first decide on the species of the sample, then select from the genomes of that species.
+The following is our reference_genomes dictionary, with input argument in alignment jobs as keys, and genome name as values:
+
+```zsh
+reference_genomes = {
+    "homo": "HG38-PLUS",
+    "hg38-plus": "HG38-PLUS",
+    "homo.gencode.v30.ERCC.chrM": "homo.gencode.v30.annotation.ERCC92",
+    "mus": "MM10-PLUS",
+    "mm10-plus": "MM10-PLUS",
+    "mm10-1.2.0": "mm10-1.2.0",
+    "mus-premrna": "mm10-1.2.0-premrna",
+    "mm10-1.2.0-premrna": "mm10-1.2.0-premrna",
+    "hg19-mm10-3.0.0": "hg19-mm10-3.0.0",
+    "microcebus": "MicMur3-PLUS",
+    "gencode.vM19": "gencode.vM19",
+    "GRCh38_premrna": "GRCh38_premrna",
+    "zebrafish-plus": "danio_rerio_plus_STAR2.6.1d"
+}
+```  
+
+The genomes above span four species: human, mouse, mouse lemur, and zebrafish.
+Human genomes are shown below:
+```zsh
+human_genomes = {
+    "homo": "HG38-PLUS"
+    "hg38-plus": "HG38-PLUS"
+    "homo.gencode.v30.ERCC.chrM": "homo.gencode.v30.annotation.ERCC92"
+    "GRCh38_premrna": "GRCh38_premrna"
+}
+```
+
+The first and second keys point to the same genome, and that's because the first one - "homo" - is deprecated. Other than that, genome "HG38-PLUS" is taken from the homo sapiens genome from UCSC, available on the website of [Illumina iGenomes](https://support.illumina.com/sequencing/sequencing_software/igenome.html). The third genome, "homo.gencode.v30.annotation.ERCC92", is taken from [GENCODE Human Release 30](https://www.gencodegenes.org/human/release_30.html). "chrM" in the key means mitochondria chromosomes - thus genes - are included in this genome, and "[ERCC92](https://www.thermofisher.com/order/catalog/product/4456740#/4456740)" means external controls of RNA variations are applied, using 92 transcripts. The last genome, "GRCh38_premrna", is taken from [Ensembl](https://uswest.ensembl.org/Homo_sapiens/Info/Index), where "premrna" means the genome includes unspliced RNA.
+
+Then we move to mouse genomes:
+```zsh
+mouse_genomes = {
+    "mus": "MM10-PLUS"
+    "mm10-plus": "MM10-PLUS"
+    "mm10-1.2.0": "mm10-1.2.0"
+    "mus-premrna": "mm10-1.2.0-premrna"
+    "mm10-1.2.0-premrna": "mm10-1.2.0-premrna"
+    "gencode.vM19": "gencode.vM19"
+}
+```
+
+Again, the first and fourth keys are deprecated. "mm10-plus" is now the key to get genome "MM10-PLUS", and "mm10-1.2.0-premrna" for genome "mm10-1.2.0-premrna". "MM10-PLUS" is taken from the *Mus musculus* (Mouse) genome from UCSC, available on the website of [Illumina iGenomes](https://support.illumina.com/sequencing/sequencing_software/igenome.html). Both "mm10-1.2.0" and "mm10-1.2.0-premrna" are taken from [Ensembl Release 84](https://support.10xgenomics.com/single-cell-gene-expression/software/release-notes/build#mm10_1.2.0), and they're available for download following the instructions on 10x Genomics website. Differences among the above genomes are that "MM10-PLUS" includes a few transgenes (genes inserted and transcribed), "mm10-1.2.0" has better genomic and mitochondria annotation, and "mm10-1.2.0-premrna" further includes unspliced RNA. The last genome "gencode.vM19" is taken from [GENCODE Mouse Release 19](https://www.gencodegenes.org/mouse/release_M19.html).
+
+To wrap up human and mouse sections, `"[hg19-mm10-3.0.0": "hg19-mm10-3.0.0](https://support.10xgenomics.com/single-cell-gene-expression/software/release-notes/build#hg19mm10_3.0.0)"` is the human and mouse genome, downloadable also on 10X Genomics website.
+
+Now we have two genomes left. "danio_rerio_plus_STAR2.6.1d" is the danio rerio (zebrafish) genome taken from [Ensembl](https://uswest.ensembl.org/Danio_rerio/Info/Index). "MicMur3-PLUS" is the mouse lemur genome taken from [Ensembl](https://uswest.ensembl.org/Microcebus_murinus/Info/Index), and you can browse the genome on the website of [UCSC](http://genome-preview.cse.ucsc.edu/cgi-bin/hgTracks?db=micMur3&lastVirtModeType=default&lastVirtModeExtraState=&virtModeType=default&virtMode=0&nonVirtPosition=&position=chr17%3A30720951%2D30776185&hgsid=394238320_4HFkLIDhzsNba96BNgHUlsvY5Ldc).
+
+After selecting a proper genome, you can go ahead running the alignment job.
+
+#### How to launch alignment jobs:
+
 *Important change: you need to explicitly specify the input and output paths for your alignment.*
 
-To the run the first of ten partitions:
+The following shows an example to align using STAR and htseq, running the first of ten partitions. Don't forget to include "--taxon", "--num_partitions", "--partition_id", "--s3_input_path", and "--s3_output_path" in the command since the arguments are not positional, and their sequence doesn't matter:
 
 ```zsh
-(utilities-env) ➜ evros alignment.run_star_and_htseq --taxon mm10-plus --num_partitions 10 --partition_id 0 --s3_input_path s3://input-bucket/path/to/fastqs --s3_output_path s3://output-bucket/path/for/results
+(utilities-env) ➜ evros alignment.run_star_and_htseq --taxon homo.gencode.v30.ERCC.chrM --num_partitions 10 --partition_id 0 --s3_input_path s3://tabula-sapiens/Pilot1/fastqs/smartseq2/pilot/B107809_A10_S130 --s3_output_path s3://output-bucket/path/for/results
 ```
 
-This will find all `.fastq.gz` files under the given input path and align them to to the MM10-PLUS genome.
+This will find all `.fastq.gz` files under the given input path and align them to to the homo.gencode.v30.ERCC.chrM genome.
 
-You can use this helper script to create a bunch of commands:
+Likewise, to align a 10x run, take the following code as an example:
 
 ```zsh
-(utilities-env) ➜ aws_star mm10-plus 10 --s3_input_path s3://input-bucket/path/to/fastqs --s3_output_path s3://output-bucket/path/for/results > my_star_jobs.sh
+(utilities-env) ➜ evros alignment.10x_count --taxon homo.gencode.v30.ERCC.chrM --s3_input_dir s3://tabula-sapiens/Pilot2/TABULA_SAPIENS_PILOT_2/TSP2_BM_vertebralbody_1_1 --s3_output_dir s3://output-bucket-name/path/for/results
+```
+
+Running either run_star_and_htseq or 10x_count launches an alignment job on AWS Batch, and you'll get the jobID from the terminal. Copy and paste that jobID into the search box on AWS Batch Job page, and the job you just launched will pop out. You don't need to do anything else there - the job status will turn from runnable to starting and then running automatically. Usually alignment using run_star_and_htseq takes around half an hour, and alignment using 10x_count takes hours.
+
+You can use the helper script below, replacing inputs with your values, to create a bunch of commands to efficiently align using STAR and htseq, instead of running one sample at a time. Mind that the only tag you need to include in running aws_star is "--s3_output_path". All the other required arguments - taxon, num_partitions, s3_input_path - are positional arguments that only look for values, and should be entered in the correct sequence. Argument num_partitions is the number of jobs you want to launch to align all the sample reads under the input folder, and partition_id tags each job with integers from 0 to num_partitions - 1. For example, if there're 200 sample folders under the input folder, and we enter 10 for num_partitions, then each job runs 20 samples. The job with partition_id 0 runs 1st, 11th, 21st, ..., 191th samples, and likewise for jobs with other partition_id.
+
+```zsh
+(utilities-env) ➜ aws_star homo.gencode.v30.ERCC.chrM 10 s3://tabula-sapiens/Pilot1/fastqs/smartseq2/pilot --s3_output_path s3://output-bucket/path/for/results > my_star_jobs.sh
 (utilities-env) ➜ cat my_star_jobs.sh
-evros --branch master alignment.run_star_and_htseq --taxon mus --num_partitions 10 --partition_id 0 --s3_input_path s3://input-bucket/path/to/fastqs --s3_output_path s3://output-bucket/path/for/results
+eevros --branch master alignment.run_star_and_htseq --taxon homo.gencode.v30.ERCC.chrM --num_partitions 10 --partition_id 0 --s3_input_path s3://tabula-sapiens/Pilot1/fastqs/smartseq2/pilot --s3_output_path s3://output-bucket/path/for/results
 sleep 10
-[...lots more...]
+[...lots more, with increasing partition_id totaling num_partitions...]
 (utilities-env) ➜ source my_star_jobs.sh
 ```
+
+This will launch multiple jobs all at once for all the samples under the input folder, which saves much time. Again, copy the jobIDs printed in the terminal and paste them on AWS Batch Job page will give you information about the status of all those jobs.
 
 #### How to check for failed alignment jobs:
 
@@ -259,3 +328,44 @@ By default this will share data in the `czb-seqbot` bucket. If you want to share
 ```
 
 If you need someone to _upload_ data to our S3 storage, there is a separate script for that, called `aws_upload`, which works similarly.
+
+## Troubleshooting
+
+### AWS Configure
+
+It's necesary to configure the AWS Command Line Interface (AWS CLI) to launch AWS Batch jobs. Otherwise, you may get the following error:
+
+``` zsh
+ERROR:aegea:Failed to install Lambda helper:
+ERROR:aegea:NoRegionError: You must specify a region.
+ERROR:aegea:Aegea will be unable to look up logs for old Batch jobs.
+The AWS CLI is not configured. Please configure it using instructions at http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html
+```
+To fix the error, go to the website for detailed instructions. Sample codes from the website is pasted below. Replace the sample values with your own values to configure the AWS CLI:
+
+```zsh
+(utilities-env) ➜ aws configure
+AWS Access Key ID [None]:
+AWS Secret Access Key [None]:
+Default region name [None]: us-west-2
+Default output format [None]: json
+```
+### Aegea Version
+
+If you get errors and exceptions similar to those below, there may be problems with aegea version conflicts:
+
+```zsh
+botocore.errorfactory.ResourceNotFoundException: An error occurred (ResourceNotFoundException) when calling the GetFunction operation: Function is not found: arn:aws:lambda:us-west-2:[a number series]:function:aegea-dev-process_batch_event
+botocore.exceptions.ClientError: An error occurred (AccessDenied) when calling the PutRolePolicy operation: User: arn:aws:iam::[a number series]:user/[AWS IAM user name] is not authorized to perform: iam-PutRolePolicy on resource: role aegea-dev-process_batch_event
+chalice.deploy.deployer.ChaliceDeploymentError: ERROR - While deploying your chalice application, received the following error:
+
+  An error occurred (AccessDenied) when calling the PutRolePolicy operation: 
+  User: arn:aws:iam::[a number series]:user/[AWS IAM user name] is not authorized to perform: 
+  iam-PutRolePolicy on resource: role aegea-dev-process_batch_event
+```
+
+To fix the error, try installing aegea version 2.6.9 which is compatible with the codes of this repo:
+
+```zsh
+(utilities-env) ➜ pip install aegea==2.6.9
+```


### PR DESCRIPTION
Some comments about the changes I made:
1. I added alignment.run_star_and_htseq to the quick reference table to help users understand the paralleled relationship between alignment.10x_count and alignment.run_star_and_htseq, and the "subsidiary" relationship between alignment.run_star_and_htseq and aws_star. After I complete coding the script that create a shell for 10x_count runs, I will leave only aws_star and say aws_10x_count in the quick reference table.
2. Please help check some information about reference genomes as I was likely making mistakes in those: 1) In the subsection "How to launch alignment jobs", not pretty sure whether I used the proper genomes in the coding examples of running 10x_count, run_star_and_htseq, and aws_star. 2) Not sure if the links I attached in the reference genome section are accurate.

Some possible next steps that I have in my mind. Some of them may be too trivial or unnecessary, but I could work on them if they sound good:
1. For now --s3_output_path is the only non-positional argument in aws_star. I could make it either positional as the other arguments, or make all the arguments non-positional (which I think is clearer).
2. aws_star uses --s3_input_path and 10x alignment uses --s3_input_dir. Could change both to be "path" or "dir".
3. Delete the num_partitions and partition_id arguments in run_star_and_htseq since these two arguments are designed to handle multiple samples at one time, but the input folder for run_star_and_htseq is a single sample. Deleting the two arguments could help prevent confusion.
4. Update genomes to the latest releases