### PR TITLE
Add Botryllus as an option for cellranger/run_10x_count

### DIFF
--- a/src/utilities/alignment/run_10x_count.py
+++ b/src/utilities/alignment/run_10x_count.py
@@ -32,6 +32,7 @@ reference_genomes = {
     "gencode.vM19": "gencode.vM19",
     "GRCh38_premrna": "GRCh38_premrna",
     "zebrafish-plus": "danio_rerio_plus_STAR2.6.1d",
+    "botryllus": "botryllus"
 }
 deprecated = {
     "homo": "hg38-plus",


### PR DESCRIPTION
Made the `.tgz` file from the folder created by `cellranger mkref` and am currently uploading to s3:

```
 ✘  Wed  7 Oct - 10:14  ~/data_lg/czbiohub-reference/botryllus/2020-10-07/cellranger 
 olga@lrrr 
tar -zcvf botryllus.tgz botryllus                                                     $(aws_prompt_info)
botryllus/
botryllus/fasta/
botryllus/fasta/genome.fa
botryllus/fasta/genome.fa.fai
botryllus/pickle/
botryllus/pickle/genes.pickle
botryllus/star/
botryllus/star/chrName.txt
botryllus/star/exonInfo.tab
botryllus/star/SAindex
botryllus/star/Genome
botryllus/star/geneInfo.tab
botryllus/star/sjdbList.out.tab
botryllus/star/sjdbInfo.txt
botryllus/star/transcriptInfo.tab
botryllus/star/sjdbList.fromGTF.out.tab
botryllus/star/chrLength.txt
botryllus/star/genomeParameters.txt
botryllus/star/chrStart.txt
botryllus/star/SA
botryllus/star/chrNameLength.txt
botryllus/star/exonGeTrInfo.tab
botryllus/reference.json
botryllus/genes/
botryllus/genes/genes.gtf

 Wed  7 Oct - 10:22  ~/data_lg/czbiohub-reference/botryllus/2020-10-07/cellranger 
 olga@lrrr  aws s3 cp botryllus.tgz s3://czbiohub-reference/cellranger                                  Completed 2.7 GiB/5.2 GiB (56.8 MiB/s) with 1 file(s) remaining
```